### PR TITLE
Fixed missing parentheses in generated CsvClassMap class constructor

### DIFF
--- a/src/Orc.CsvHelper/Orc.CsvHelper.Shared/CodeGeneration/CodeGeneration.cs
+++ b/src/Orc.CsvHelper/Orc.CsvHelper.Shared/CodeGeneration/CodeGeneration.cs
@@ -51,7 +51,7 @@ namespace Orc.Csv
             {
                 var propertyName = ToCamelCase(fieldHeader);
                 properties.Add(string.Format("public string {0} {1}", propertyName, getSet));
-                propertyMaps.Add(string.Format("this.Map(x => x.{0}).Name(\"{1}\");", propertyName, fieldHeader));
+                propertyMaps.Add(string.Format("Map(x => x.{0}).Name(\"{1}\");", propertyName, fieldHeader));
             }
 
             if (!Directory.Exists(outputFolder))
@@ -95,9 +95,9 @@ namespace Orc.Csv
             sb.AppendLine("{");
             sb.AppendLine(string.Format("{0}using CsvHelper.Configuration;", Spaces(4)));
             sb.AppendLine("");
-            sb.AppendLine(string.Format("{0}public class {1} : CsvClassMap<{2}>", Spaces(4), classNameMap, className));
+            sb.AppendLine(string.Format("{0}public sealed class {1} : CsvClassMap<{2}>", Spaces(4), classNameMap, className));
             sb.AppendLine(Spaces(4) + "{");
-            sb.AppendLine(string.Format("{0}public {1}", Spaces(8), classNameMap));
+            sb.AppendLine(string.Format("{0}public {1}()", Spaces(8), classNameMap));
             sb.AppendLine(Spaces(8) + "{");
             foreach (var property in properties)
             {


### PR DESCRIPTION
Geert, could you please merge this request, then create and deploy the built package to NuGet?
I've tested the generated code in a real project, with WildGums Resharper and StyleCoop settings and according this, I've done two more non functional changes to conform WildGums standards: no redundant 'this' and map class made 'sealed'.